### PR TITLE
Allow optional 'options' in 'citeSyntax'.

### DIFF
--- a/micromark-extension-cite/src/index.ts
+++ b/micromark-extension-cite/src/index.ts
@@ -162,7 +162,7 @@ export const citeSyntax = (function (options?: Partial<CiteSyntaxOptions>): Synt
 
 	// assemble extension
 	return { text };
-}) as (options: Partial<CiteSyntaxOptions>) => MM.SyntaxExtension;
+}) as (options?: Partial<CiteSyntaxOptions>) => MM.SyntaxExtension;
 
 ////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Need to carry over '?' to typecast declaration. I do not believe tests are not catching this.